### PR TITLE
Speedup for large datasets

### DIFF
--- a/lib/protocol/Parser.js
+++ b/lib/protocol/Parser.js
@@ -7,9 +7,9 @@
 // http: //www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing,
-// software distributed under the License is distributed on an 
+// software distributed under the License is distributed on an
 // "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
-// either express or implied. See the License for the specific 
+// either express or implied. See the License for the specific
 // language governing permissions and limitations under the License.
 'use strict';
 
@@ -70,18 +70,16 @@ Parser.prototype.createTransform = function createTransform(rs, options) {
 };
 
 function createFunctionBody(metadata, nameProperty) {
-  var functionBody = ['var obj = {};'];
 
   function addParseColumnLine(column, index) {
     var fn = ReadFunction[column.dataType];
     if (column.dataType === TypeCode.DECIMAL) {
       fn = util.format(fn, column.fraction);
     }
-    var key = (typeof nameProperty === 'string') ? column[nameProperty] :
-      index;
-    functionBody.push('obj["' + key + '"] = this.' + fn + ';');
+    var key = (typeof nameProperty === 'string') ? column[nameProperty] : index;
+    return '"' + key + '" : this.' + fn;
   }
-  metadata.forEach(addParseColumnLine);
-  functionBody.push('return obj;');
-  return functionBody.join('\n');
+  var bodyColumns = metadata.map(addParseColumnLine);
+  var functionBody = 'return {\n' + bodyColumns.join(', \n') + '};';
+  return functionBody;
 }


### PR DESCRIPTION
Hi,

I found that the parser is faster when the row objects are created directly. I found this to improve performance by about 10% for select statements with large results. I can send you the benchmarking scripts if you like.

Best regards,
Valentin
