### PR TITLE
process ID is configurable

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -18,6 +18,7 @@ exports.util.extend(exports, require('./protocol'));
 exports.Client = require('./Client');
 
 exports.createClient = function createClient(options) {
+  exports.util.cPid = options.clientPid; // setup static process ID
   return new exports.Client(options);
 };
 

--- a/lib/util/index.js
+++ b/lib/util/index.js
@@ -21,6 +21,7 @@ var path = require('path');
 var os = require('os');
 var fs = require('fs');
 
+var cPid;
 Object.defineProperties(exports, {
   setImmediate: {
     get: function setImmediate() {
@@ -32,7 +33,15 @@ Object.defineProperties(exports, {
   },
   cid: {
     get: function getClientId() {
-      return [exports.pid || 'nodejs', os.hostname()].join('@');
+      return [this.cPid, os.hostname()].join('@');
+    }
+  },
+  cPid: {
+    get: function getClientPid() {
+      return cPid || exports.pid || 'nodejs';
+    },
+    set: function setClientPid(clientPid) {
+      cPid = clientPid;
     }
   }
 });


### PR DESCRIPTION
This additional option comes handy when a user is connected to HANA with a *sessionCookie*, and the node-process needs to be restarted.
By setting a fix process ID, the *sessionCookie* can be reused after the restart.

