### PR TITLE
Introduce basic multihost support

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,19 @@ var client = hdb.createClient({
 });
 ```
 
+Multiple hosts can be provided to the client as well:
+
+```js
+var hdb    = require('hdb');
+var client = hdb.createClient({
+  hosts : [ { host: 'host1', port: 30015 }, { host: 'host2', port: 30015 } ],
+  user     : 'user',
+  password : 'secret'
+});
+```
+
+This is suitable for Multiple-host HANA systems which are distributed over several hosts. The client will establish a connection to the first available host from the list.
+
 ### Authentication mechanisms
 Details about the different authentication method can be found in the [SAP HANA Security Guide](http://help.sap.com/hana/SAP_HANA_Security_Guide_en.pdf).
 

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -19,6 +19,7 @@ var protocol = require('./protocol');
 var Connection = protocol.Connection;
 var Result = protocol.Result;
 var Statement = protocol.Statement;
+var ConnectionManager = protocol.ConnectionManager;
 
 module.exports = Client;
 
@@ -32,8 +33,9 @@ function Client(options) {
     holdCursorsOverCommit: true,
     scrollableCursor: true
   }, options);
+
+  this._connManager = new ConnectionManager(this._settings);
   this._connection = this._createConnection(this._settings);
-  this._addListeners(this._connection);
 }
 
 Object.defineProperties(Client.prototype, {
@@ -118,7 +120,8 @@ Client.prototype.connect = function connect(options, cb) {
     options = {};
   }
 
-  var opts = processOptions.call(this, options);
+  this._connManager.updateState(options);
+  var connectOptions = this._connManager.getConnectOptions();
 
   // SAML assertion can only be used once
   if (this._settings.assertion) {
@@ -140,17 +143,17 @@ Client.prototype.connect = function connect(options, cb) {
     if (err) {
       return done(err);
     }
-    self._connection.connect(opts.connect, done);
+    self._addListeners(self._connection);
+    self._connection.connect(connectOptions, done);
   }
 
   if (this._connection.readyState === 'new') {
-    openNetworkConnection.call(this, opts.open, opts.multiDb, onopen);
+    this._connManager.openConnection(this._connection, onopen);
   } else if (this._connection.readyState === 'closed') {
     this._connection = this._createConnection(this._settings);
-    this._addListeners(this._connection);
-    openNetworkConnection.call(this, opts.open, opts.multiDb, onopen);
+    this._connManager.openConnection(this._connection, onopen);
   } else if (this._connection.readyState === 'disconnected') {
-    this._connection.connect(opts.connect, done);
+    this._connection.connect(connectOptions, done);
   } else {
     if (util.isFunction(cb)) {
       util.setImmediate(function deferError() {
@@ -163,116 +166,6 @@ Client.prototype.connect = function connect(options, cb) {
   }
   return this;
 };
-
-function processOptions(options) {
-  /* jshint validthis:true */
-  var opts = {};
-
-  var settings = this._settings;
-
-  function addOption(name) {
-    /* jshint validthis:true */
-    if (name in settings) {
-      this[name] = settings[name];
-    }
-  }
-
-  var openOptions = {
-    host: settings.host,
-    port: settings.port
-  };
-  ['pfx', 'key', 'cert', 'ca', 'passphrase', 'rejectUnauthorized',
-    'secureProtocol'
-  ].forEach(addOption, openOptions);
-  util.extend(openOptions, options);
-  opts.open = openOptions;
-
-  var connectOptions = {};
-  ['user', 'password', 'assertion', 'sessionCookie'].forEach(addOption,
-    connectOptions);
-  util.extend(connectOptions, options);
-  opts.connect = connectOptions;
-
-  var multiDbOptions = {};
-  ['databaseName', 'instanceNumber'].forEach(addOption, multiDbOptions);
-  util.extend(multiDbOptions, options);
-  opts.multiDb = multiDbOptions;
-
-  return opts;
-}
-
-function openNetworkConnection(openOptions, multiDbOptions, cb) {
-  /* jshint validthis:true */
-
-  var dbName = multiDbOptions.databaseName;
-  if (util.isString(dbName) && dbName.length) {
-    openNetworkConnectMultiDbCase.call(this, openOptions, multiDbOptions, cb);
-  } else {
-    this._connection.open(openOptions, cb);
-  }
-}
-
-function openNetworkConnectMultiDbCase(openOptions, multiDbOptions, cb) {
-  /* jshint validthis:true */
-  var self = this;
-
-  if (!openOptions.port) {
-    var instanceNum = extractInstanceNumber();
-    if (isNaN(instanceNum)) {
-      return cb(new Error('Instance Number is not valid'));
-    } else {
-      openOptions.port = 30013 + (instanceNum * 100);
-    }
-  }
-
-  function extractInstanceNumber() {
-    var instanceNumber = multiDbOptions.instanceNumber;
-    if (util.isNumber(instanceNumber)) {
-      return instanceNumber;
-    }
-    if (util.isString(instanceNumber) && instanceNumber.length) {
-      return parseInt(instanceNumber, 10);
-    }
-    return NaN;
-  }
-
-  var tempConn = this._createConnection(this._settings);
-  function onError(err) {
-    self.emit('error', err);
-  }
-  tempConn.on('error', onError);
-
-  function handleError(err) {
-    tempConn.close();
-    cb(err);
-  }
-
-  tempConn.open(openOptions, function (err) {
-    if (err) {
-      return handleError(err);
-    }
-
-    tempConn.fetchDbConnectInfo(multiDbOptions, function (err, info) {
-      if (err) {
-        return handleError(err);
-      }
-
-      if (info.isConnected) {
-        // Connection to target DB is already established so just reuse it
-        self._connection.close();
-        tempConn.removeListener('error', onError);
-        self._addListeners(tempConn);
-        self._connection = tempConn;
-        cb(null);
-      } else {
-        tempConn.close();
-        openOptions.host = info.host;
-        openOptions.port = info.port;
-        self._connection.open(openOptions, cb);
-      }
-    });
-  });
-}
 
 Client.prototype.disconnect = function disconnect(cb) {
   var self = this;

--- a/lib/protocol/Connection.js
+++ b/lib/protocol/Connection.js
@@ -507,6 +507,13 @@ Connection.prototype.fetchDbConnectInfo = function (options, cb) {
   });
 };
 
+Connection.prototype._closeSilently = function _closeSilently() {
+  if (this._socket) {
+    this._socket.removeAllListeners('close');
+    this.close();
+  }
+};
+
 Connection.prototype.close = function close() {
   var self = this;
 

--- a/lib/protocol/ConnectionManager.js
+++ b/lib/protocol/ConnectionManager.js
@@ -1,0 +1,133 @@
+// Copyright 2013 SAP AG.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http: //www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+// either express or implied. See the License for the specific
+// language governing permissions and limitations under the License.
+'use strict';
+
+var State = require('./ConnectionManagerState');
+var util = require('../util');
+var debug = util.debuglog('hdb_conn');
+
+module.exports = ConnectionManager;
+
+function ConnectionManager(settings) {
+  this.state = new State(settings);
+}
+
+ConnectionManager.prototype.updateState = function updateState(newOptions) {
+  this.state.update(newOptions);
+};
+
+ConnectionManager.prototype.getConnectOptions = function getConnectOptions() {
+  return this.state.options.connect;
+};
+
+ConnectionManager.prototype.openConnection = function openConnection(conn, cb) {
+  var dbHosts = this.state.dbHosts;
+  debug('Opening connection. Hosts:', dbHosts);
+
+  this._openConnectionToHost(conn, dbHosts, 0, [], cb);
+};
+
+ConnectionManager.prototype._openConnectionToHost = function _openConnectionToHost(conn, dbHosts, whichHost, errorStats, cb) {
+  if (whichHost === dbHosts.length) {
+    return cb(couldNotOpenConnectionError(errorStats));
+  }
+
+  var self = this;
+  var currentHostOptions = dbHosts[whichHost];
+  var openOptions = util.extend({}, currentHostOptions, this.state.options.encryption);
+  this._openConnection(conn, openOptions, function (err) {
+    if (!err) {
+      debug('Successful connection to %s:%d', openOptions.host, openOptions.port);
+      return cb(null);
+    }
+    debug('Connection to %s:%d failed with:', openOptions.host, openOptions.port, err.message);
+    errorStats.push({ host: openOptions.host, port: openOptions.port, err: err });
+    self._openConnectionToHost(conn, dbHosts, (whichHost + 1), errorStats, cb);
+  });
+};
+
+ConnectionManager.prototype._openConnection = function _openConnection(conn, openOptions, cb) {
+  var dbName = this.state.options.multiDb.databaseName;
+  if (util.isString(dbName) && dbName.length) {
+    this._openConnectionMultiDbCase(conn, openOptions, cb);
+  } else {
+    conn.open(openOptions, cb);
+  }
+};
+
+ConnectionManager.prototype._openConnectionMultiDbCase = function _openConnectionMultiDbCase(conn, openOptions, cb) {
+  var multiDbOptions = this.state.options.multiDb;
+
+  if (!openOptions.port) {
+    var instanceNum = extractInstanceNumber(multiDbOptions.instanceNumber);
+    if (isNaN(instanceNum)) {
+      return cb(new Error('Instance Number is not valid'));
+    } else {
+      openOptions.port = 30013 + (instanceNum * 100);
+    }
+  }
+
+  function onError(err) {
+    cb(err);
+  }
+  conn.on('error', onError);
+
+  function handleError(err) {
+    conn.close();
+    cb(err);
+  }
+
+  conn.open(openOptions, function (err) {
+    if (err) {
+      return handleError(err);
+    }
+
+    conn.fetchDbConnectInfo(multiDbOptions, function (err, info) {
+      if (err) {
+        return handleError(err);
+      }
+
+      if (info.isConnected) {
+        conn.removeListener('error', onError);
+        cb(null);
+      } else {
+        conn._closeSilently();
+        openOptions.host = info.host;
+        openOptions.port = info.port;
+        debug('Connecting to tenant-db %s on %s:%d', multiDbOptions.databaseName, openOptions.host, openOptions.port);
+        conn.open(openOptions, cb);
+      }
+    });
+  });
+};
+
+function extractInstanceNumber(instanceNumber) {
+  if (util.isNumber(instanceNumber)) {
+    return instanceNumber;
+  }
+  if (util.isString(instanceNumber) && instanceNumber.length) {
+    return parseInt(instanceNumber, 10);
+  }
+  return NaN;
+}
+
+function couldNotOpenConnectionError(errorStats) {
+  var message = 'Could not connect to any host:';
+  errorStats.forEach(function (stats) {
+    message += util.format(' [ %s:%d - %s ]', stats.host, stats.port, stats.err.message);
+  });
+  var err = new Error(message);
+  err.code = 'EHDBOPENCONN';
+  return err;
+}

--- a/lib/protocol/ConnectionManagerState.js
+++ b/lib/protocol/ConnectionManagerState.js
@@ -1,0 +1,70 @@
+// Copyright 2013 SAP AG.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http: //www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+// either express or implied. See the License for the specific
+// language governing permissions and limitations under the License.
+'use strict';
+
+module.exports = ConnectionManagerState;
+
+var ENCRYPTION_OPTIONS = ['pfx', 'key', 'cert', 'ca', 'passphrase', 'rejectUnauthorized', 'secureProtocol'];
+var CONNECT_OPTIONS = ['user', 'password', 'assertion', 'sessionCookie'];
+var MULTIDB_OPTIONS = ['databaseName', 'instanceNumber'];
+
+function ConnectionManagerState(initialOptions) {
+  this.initialOptions = initialOptions;
+
+  this.dbHosts = undefined;
+  this.options = {
+    encryption: undefined,
+    connect: undefined,
+    multiDb: undefined
+  };
+}
+
+ConnectionManagerState.prototype.update = function update(newOptions) {
+  newOptions = newOptions || {};
+  this.dbHosts = this._processHostOptions(newOptions);
+  this.options.encryption = this._combineOptions(ENCRYPTION_OPTIONS, newOptions);
+  this.options.connect = this._combineOptions(CONNECT_OPTIONS, newOptions);
+  this.options.multiDb = this._combineOptions(MULTIDB_OPTIONS, newOptions);
+};
+
+ConnectionManagerState.prototype._processHostOptions = function _processHostOptions(newOptions) {
+  var initialOptions = this.initialOptions;
+
+  if (Array.isArray(newOptions.hosts)) {
+    return newOptions.hosts;
+  }
+
+  if (newOptions.host || newOptions.port) {
+    return [{ host: newOptions.host || initialOptions.host, port: newOptions.port || initialOptions.port }];
+  }
+
+  if (Array.isArray(initialOptions.hosts)) {
+    return initialOptions.hosts;
+  }
+
+  return [{ host: initialOptions.host, port: initialOptions.port }];
+};
+
+ConnectionManagerState.prototype._combineOptions = function _combineOptions(arrNames, newOptions) {
+  var initialOptions = this.initialOptions;
+  var result = {};
+
+  arrNames.forEach(function addOption(name) {
+    if (name in newOptions || name in initialOptions) {
+      result[name] = newOptions[name] || initialOptions[name];
+    }
+  });
+
+  return result;
+};

--- a/lib/protocol/index.js
+++ b/lib/protocol/index.js
@@ -14,6 +14,7 @@
 'use strict';
 
 exports.Connection = require('./Connection');
+exports.ConnectionManager = require('./ConnectionManager');
 exports.ClientInfo = require('./ClientInfo');
 exports.Parser = require('./Parser');
 exports.Result = require('./Result');

--- a/test/lib.Connection.js
+++ b/test/lib.Connection.js
@@ -134,6 +134,38 @@ describe('Lib', function () {
       connection.readyState.should.equal('closed');
     });
 
+    it('#_closeSilently - should do nothing if there is no socket', function () {
+      var connection = createConnection();
+      connection.readyState.should.equal('new');
+      connection._closeSilently();
+      connection.readyState.should.equal('new');
+    });
+
+    it('#_closeSilently - should close the socket of a connection, but keep the state', function () {
+      var connection = createConnection();
+      var listenersRemoved = false;
+      var socketDestroyed = false;
+      connection._socket = {
+        readyState: 'open',
+        destroy: function () {
+          socketDestroyed = true;
+        },
+        removeAllListeners: function (eventName) {
+          eventName.should.equal('close');
+          listenersRemoved = true;
+        }
+      };
+
+      connection.on('close', function () {
+        throw new Error('Close vent should not have been emitted');
+      });
+
+      connection._closeSilently();
+      connection._state.should.be.instanceof(Object);
+      listenersRemoved.should.equal(true);
+      socketDestroyed.should.equal(true);
+    });
+
     it('should open and close a Connection', function (done) {
       var connection = createConnection();
       connection.open({}, function (err) {

--- a/test/lib.ConnectionManagerState.js
+++ b/test/lib.ConnectionManagerState.js
@@ -1,0 +1,207 @@
+// Copyright 2013 SAP AG.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http: //www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+// either express or implied. See the License for the specific
+// language governing permissions and limitations under the License.
+'use strict';
+/*jshint expr:true*/
+
+var State = require('../lib/protocol/ConnectionManagerState');
+
+describe('Lib', function () {
+
+  describe('#ConnectionManagerState', function () {
+
+    describe('#_processHostOptions', function () {
+
+      it('should return the initial host and port', function () {
+        var state = new State({ host: 'localhost', port: 30015 });
+        var actual = state._processHostOptions({});
+
+        actual.should.deepEqual([{ host: 'localhost', port: 30015 }]);
+      });
+
+      it('should return the new host and port', function () {
+        var state = new State({ host: 'localhost', port: 30015 });
+        var actual = state._processHostOptions({ host: 'other.host', port: 31115 });
+
+        actual.should.deepEqual([{ host: 'other.host', port: 31115 }]);
+      });
+
+      it('should return initial host and new port', function () {
+        var state = new State({ host: 'localhost', port: 30015 });
+        var actual = state._processHostOptions({ port: 31115 });
+
+        actual.should.deepEqual([{ host: 'localhost', port: 31115 }]);
+      });
+
+      it('should return new host and initial port', function () {
+        var state = new State({ host: 'localhost', port: 30015 });
+        var actual = state._processHostOptions({ host: 'other.host' });
+
+        actual.should.deepEqual([{ host: 'other.host', port: 30015 }]);
+      });
+
+      it('should return the initial hosts and ignore the host and port properties', function () {
+        var state = new State({ host: 'localhost', port: 30015, hosts: [{ host: 'other.host', port: 31115 }] });
+        var actual = state._processHostOptions({});
+
+        actual.should.deepEqual([{ host: 'other.host', port: 31115 }]);
+      });
+
+      it('should return the new hosts and ignore the host and port properties', function () {
+        var state = new State({ hosts: [{ host: 'localhost', port: 30015 }] });
+        var actual = state._processHostOptions({ host: 'other.host', port: 31115, hosts: [{ host: 'other.host.2', port: 32215 }] });
+
+        actual.should.deepEqual([{ host: 'other.host.2', port: 32215 }]);
+      });
+
+      it('should return the new host and port and ignore the initial hosts', function () {
+        var state = new State({ hosts: [{ host: 'localhost', port: 30015 }] });
+        var actual = state._processHostOptions({ host: 'other.host', port: 31115 });
+
+        actual.should.deepEqual([{ host: 'other.host', port: 31115 }]);
+      });
+
+      it('should return the new hosts and ignore the initial host and port', function () {
+        var state = new State({ host: 'localhost', port: 30015 });
+        var actual = state._processHostOptions({ hosts: [{ host: 'other.host', port: 31115 }] });
+
+        actual.should.deepEqual([{ host: 'other.host', port: 31115 }]);
+      });
+
+    });
+
+    describe('#_combineOptions', function () {
+
+      it('should return the initial options', function () {
+        var initialOptions = { a: 1, b: 2, c: 3 };
+        var state = new State(initialOptions);
+
+        var actual = state._combineOptions(['a', 'b', 'c'], {});
+        actual.should.deepEqual(initialOptions);
+      });
+
+      it('should return the new options', function () {
+        var newOptions = { a: 11, b: 22, c: 33 };
+        var state = new State({});
+
+        var actual = state._combineOptions(['a', 'b', 'c'], newOptions);
+        actual.should.deepEqual(newOptions);
+      });
+
+      it('should return a mixture of initial and new options', function () {
+        var initialOptions = { a: 1, b: 2 };
+        var newOptions = { b: 22, c: 33 };
+        var state = new State(initialOptions);
+
+        var expectedOptions = { a: 1, b: 22, c: 33 };
+        var actual = state._combineOptions(['a', 'b', 'c'], newOptions);
+        actual.should.deepEqual(expectedOptions);
+      });
+
+      it('should not take properties from the initial options that are not part of the list', function () {
+        var initialOptions = { a: 1, b: 2, c: 3 };
+        var state = new State(initialOptions);
+
+        var expectedOptions = { a: 1, b: 2 };
+        var actual = state._combineOptions(['a', 'b'], {});
+        actual.should.deepEqual(expectedOptions);
+      });
+
+      it('should not take properties from the new options that are not present in the list', function () {
+        var initialOptions = { a: 1, b: 2 };
+        var newOptions = { c: 33, d: 44 };
+        var state = new State(initialOptions);
+
+        var expectedOptions = { a: 1, b: 2, c: 33 };
+        var actual = state._combineOptions(['a', 'b', 'c'], newOptions);
+        actual.should.deepEqual(expectedOptions);
+      });
+
+      it('should work properly even if the initial options have been changed in the meantime', function () {
+        var initialOptions = { a: 1, b: 2 };
+        var newOptions = { d: 44 };
+        var state = new State(initialOptions);
+        initialOptions.b = 22;
+        initialOptions.c = 33;
+
+        var expectedOptions = { a: 1, b: 22, c: 33, d: 44 };
+        var actual = state._combineOptions(['a', 'b', 'c', 'd'], newOptions);
+        actual.should.deepEqual(expectedOptions);
+      });
+
+    });
+
+    describe('#update', function () {
+
+      it('should be ok to be called without options', function () {
+        var state = new State({});
+        state.update();
+      });
+
+      it('should call the _processHostOptions method', function () {
+        var returnedValue = [{ host: 'localhost', port: 30015 }];
+        var state = new State({});
+        state._processHostOptions = function () { return returnedValue; };
+
+        state.update({});
+        state.dbHosts.should.deepEqual(returnedValue);
+      });
+
+      function checkUpdateOfOptions(correspondingProperty, expectedOptionsList, returnedValue, whichCall) {
+        var state = new State({});
+
+        var timesCalled = 0;
+        state._combineOptions = function (arrNames, newOptions) {
+          ++timesCalled;
+          if (timesCalled === whichCall) {
+            arrNames.should.deepEqual(expectedOptionsList);
+            return returnedValue;
+          }
+        };
+
+        state.update({});
+        state.options[correspondingProperty].should.deepEqual(returnedValue);
+      }
+
+      it('should set the encryption options properly', function () {
+        var correspondingProperty = 'encryption';
+        var optionsList = ['pfx', 'key', 'cert', 'ca', 'passphrase', 'rejectUnauthorized', 'secureProtocol'];
+        var returnedValue = { ca: 'CA certificate' };
+        var whichCall = 1;
+
+        checkUpdateOfOptions(correspondingProperty, optionsList, returnedValue, whichCall);
+      });
+
+      it('should set the connect options properly', function () {
+        var correspondingProperty = 'connect';
+        var optionsList = ['user', 'password', 'assertion', 'sessionCookie'];
+        var returnedValue = { user: 'user', password: 'secret' };
+        var whichCall = 2;
+
+        checkUpdateOfOptions(correspondingProperty, optionsList, returnedValue, whichCall);
+      });
+
+      it('should set the multiDb options properly', function () {
+        var correspondingProperty = 'multiDb';
+        var optionsList = ['databaseName', 'instanceNumber'];
+        var returnedValue = { databaseName: 'DB0' };
+        var whichCall = 3;
+
+        checkUpdateOfOptions(correspondingProperty, optionsList, returnedValue, whichCall);
+      });
+
+    });
+
+  });
+
+});

--- a/test/mock/MockConnection.js
+++ b/test/mock/MockConnection.js
@@ -67,9 +67,7 @@ MockConnection.prototype.open = function open(options, cb) {
   this.readyState.should.equal('new');
   util.setImmediate(function () {
     var err = self.getError('open');
-    if (err) {
-      self.emit('error', err);
-    } else {
+    if (!err) {
       self.emit('open');
     }
     cb(err);
@@ -97,6 +95,10 @@ MockConnection.prototype.destroy = function destroy(err) {
   util.setImmediate(function () {
     self.close();
   });
+};
+
+MockConnection.prototype._closeSilently = function _closeSilently() {
+  this.readyState = 'closed';
 };
 
 MockConnection.prototype.close = function close() {


### PR DESCRIPTION
Allows specifying multiple hosts in the client's settings via the `hosts` property.