### PR TITLE
handle connect reply

### DIFF
--- a/lib/protocol/Result.js
+++ b/lib/protocol/Result.js
@@ -92,6 +92,7 @@ Result.prototype.handle = function handle(err, reply, cb) {
     return;
   case FunctionCode.NIL:
   case FunctionCode.DDL:
+  case FunctionCode.CONNECT:
     cb(null);
     return;
   case FunctionCode.DB_PROCEDURE_CALL:


### PR DESCRIPTION
since the CONNECT reply message doesn't support any parts, it should be as simple as this to handle the additional function code reply. #46 