### PR TITLE
Do not propagate socket events before calling callback of 'connect'

### DIFF
--- a/lib/Client.js
+++ b/lib/Client.js
@@ -129,9 +129,12 @@ Client.prototype.connect = function connect(options, cb) {
   }
 
   var self = this;
+  var removeTempListeners;
 
   function done(err) {
+    removeTempListeners && removeTempListeners();
     if (!err) {
+      self._addListeners(self._connection);
       self.emit('connect');
     }
     if (util.isFunction(cb)) {
@@ -143,7 +146,7 @@ Client.prototype.connect = function connect(options, cb) {
     if (err) {
       return done(err);
     }
-    self._addListeners(self._connection);
+    removeTempListeners = addTempListeners(self._connection, done);
     self._connection.connect(connectOptions, done);
   }
 
@@ -229,6 +232,30 @@ Client.prototype._prepare = function _prepare(command, options, cb) {
   });
   return this;
 };
+
+function addTempListeners(connection, cb) {
+  function connectionClosedError() {
+    var err = new Error('Connection closed unexpectedly');
+    err.code = 'EHDBCLOSE';
+    return err;
+  }
+
+  function onerror(err) {
+    cb(err);
+  }
+  connection.on('error', onerror);
+
+  function onclose() {
+    cb(connectionClosedError());
+  }
+  connection.on('close', onclose);
+
+  function removeTempListeners() {
+    connection.removeListener('error', onerror);
+    connection.removeListener('close', onclose);
+  }
+  return removeTempListeners;
+}
 
 Client.prototype._addListeners = function _addListeners(connection) {
   var self = this;

--- a/test/hdb.Client.js
+++ b/test/hdb.Client.js
@@ -93,6 +93,35 @@ describe('hdb', function () {
       });
     });
 
+    it('should not propagate socket error event during connection process', function (done) {
+      var client = new TestClient();
+      client._connection.events.connect.error = true;
+
+      client.on('error', function (err) {
+        done(err);
+      });
+
+      client.connect(function (err) {
+        err.message.should.equal('Unexpected connect error');
+        done();
+      });
+    });
+
+    it('should not propagate socket close event during connection process', function (done) {
+      var client = new TestClient();
+      client._connection.events.connect.close = true;
+
+      client.on('close', function () {
+        done(new Error("'close' event should not be emitted"));
+      });
+
+      client.connect(function (err) {
+        err.message.should.equal('Connection closed unexpectedly');
+        err.code.should.equal('EHDBCLOSE');
+        done();
+      });
+    });
+
     it('should connect with saml assertion', function (done) {
       var client = new TestClient({
         assertion: 'assertion'


### PR DESCRIPTION
Fixes https://github.com/SAP/node-hdb/issues/53