### PR TITLE
Workaround for Node 6.4.0 buffer bug

### DIFF
--- a/lib/protocol/Writer.js
+++ b/lib/protocol/Writer.js
@@ -437,7 +437,11 @@ Writer.prototype.writeCharacters = function writeCharacters(value, encoding) {
   var type = encoding === 'ascii' ? TypeCode.STRING : TypeCode.NSTRING;
   var length = Buffer.byteLength(value, encoding);
   var buffer;
-  if (length <= 245) {
+  if (length === 0 ) {
+    buffer = new Buffer(2);
+    buffer[0] = type;
+    buffer[1] = length;
+  } else if (length <= 245) {
     buffer = new Buffer(2 + length);
     buffer[0] = type;
     buffer[1] = length;


### PR DESCRIPTION
Node 6.4.0 introduced a bug ( https://github.com/nodejs/node/issues/8127 ) that causes a Range Error exceptions when writing a zero-length string to a buffer. The bug was fixed in Node 6.5.0, but the current node-hdb throws Range Error exceptions in Node 6.4.0 when attempting to use streams to read a result set.

This change introduces a workaround that checks for zero-length strings, and avoids the write that will fail in Node 6.4.0