### PR TITLE
Invoke pending callbacks in case of an error

### DIFF
--- a/lib/protocol/Connection.js
+++ b/lib/protocol/Connection.js
@@ -219,7 +219,13 @@ Connection.prototype._addListeners = function _addListeners(socket) {
   socket.on('data', ondata);
 
   function onerror(err) {
-    self.emit('error', err);
+    var cb = self._state.receive;
+    if (cb) {
+      self._state.receive = null; // a callback should be called only once
+      cb(err);
+    } else {
+      self.emit('error', err);
+    }
   }
   socket.on('error', onerror);
 
@@ -229,6 +235,13 @@ Connection.prototype._addListeners = function _addListeners(socket) {
     self.emit('close', hadError);
   }
   socket.on('close', onclose);
+
+  function onend() {
+    var err = new Error('Connection closed by server');
+    err.code = 'EHDBCLOSE';
+    socket.emit('error', err);
+  }
+  socket.on('end', onend);
 };
 
 Connection.prototype._cleanup = function _cleanup() {

--- a/test/acceptance/db.Events.js
+++ b/test/acceptance/db.Events.js
@@ -1,0 +1,51 @@
+// Copyright 2013 SAP AG.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http: //www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+// either express or implied. See the License for the specific
+// language governing permissions and limitations under the License.
+'use strict';
+
+var db = require('../db')();
+
+describe('db', function () {
+
+  describe('events', function () {
+    var client;
+
+    before(function (done) {
+      db.init(function (err) {
+        if (err) {
+          return done(err);
+        }
+
+        client = db.client;
+        done();
+      });
+    });
+
+    after(function () {
+      if (client && client.readyState !== 'closed') {
+        client.close();
+      }
+    });
+
+    it('should invoke pending callback', function (done) {
+      client.close();
+
+      client.exec('SELECT * FROM DUMMY', function (err, rs) {
+        err.should.be.an.instanceOf(Error);
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/mock/MockSocket.js
+++ b/test/mock/MockSocket.js
@@ -85,7 +85,6 @@ Object.defineProperty(MockSocket.prototype, 'readyState', {
 
 MockSocket.prototype.end = function end() {
   this.writable = false;
-  this.emit('end');
 };
 
 MockSocket.prototype.destroy = function destroy(err) {


### PR DESCRIPTION
Fixes issue https://github.com/SAP/node-hdb/issues/53

Currently the following code:

```js
var hdb = require('hdb');

var client = hdb.createClient({ /* options here */ });

client.on('error', function (err) {
  console.log('Error event:', err.message);
});

client.on('close', function (hadError) {
  console.log('Close event, had error:', hadError);
});

client.connect(function (err) {
  if (err) {
    return console.log('Connect Error:', err.message);
  }
  console.log('Successful connection');
  console.log('Closing client...');
  client.close();

  client.exec('SELECT * FROM DUMMY', function cb1(err, rs) {
    console.log('-- cb1', err && err.message);
  });

  client.exec('SELECT * FROM DUMMY', function cb2(err, rs) {
    console.log('-- cb2', err && err.message);
  });
});
```

Results in:

```
Successful connection
Closing client...
Error event: This socket is closed
Close event, had error: false
```

Thus, the callbacks of the 2 `client.exec` invocations are never called. The same thing (not calling the callback) happens in issue https://github.com/SAP/node-hdb/issues/53 as well.

With this fix the output of the same code will be:

```
Successful connection
Closing client...
-- cb1 This socket is closed
-- cb2 This socket is closed
Close event, had error: false
```

Thus, the pending callbacks (of the 2 `client.exec` invocations) are invoked with the corresponding error.

Regarding issue https://github.com/SAP/node-hdb/issues/53, the output of the code (with XSEngine port provided instead of DB port) will be:

```
Connect Error: Connection closed by server
Close event, had error: false
```