### PR TITLE
Write-back lob type

### DIFF
--- a/lib/protocol/Writer.js
+++ b/lib/protocol/Writer.js
@@ -17,6 +17,7 @@ var util = require('../util');
 var Readable = util.stream.Readable;
 var common = require('./common');
 var TypeCode = common.TypeCode;
+var Lob = require('./Lob');
 var LobOptions = common.LobOptions;
 var NormalizedTypeCode = common.NormalizedTypeCode;
 var bignum = util.bignum;
@@ -357,6 +358,8 @@ Writer.prototype.pushLob = function pushLob(buffer, value) {
     stream.push(null);
   } else if (value instanceof Readable) {
     stream = value;
+  } else if (value instanceof Lob) {
+    stream = value.createReadStream();
   } else if (value.readable === true) {
     stream = new Readable().wrap(value);
   } else {


### PR DESCRIPTION
These commits add support for writing back LOBs read from the database without being required to create read streams manually. This is handy e.g. when reading LOBs from conn A and writing to conn B.
