### PR TITLE
Fix wrong encoding in prepared statements that contain a function 

### DIFF
--- a/lib/protocol/Writer.js
+++ b/lib/protocol/Writer.js
@@ -427,41 +427,20 @@ Writer.prototype[TypeCode.DECIMAL] = function writeDecimal(value) {
 };
 
 Writer.prototype[TypeCode.NSTRING] = function writeNString(value) {
-  if (this._useCesu8) {
-    var encoded = util.convert.encode(value, true);
-    this.push(createBinaryOutBuffer(TypeCode.NSTRING, encoded));
-  } else {
-    this.writeCharacters(value, 'utf8');
-  }
+  this.writeCharacters(TypeCode.NSTRING, value);
 };
 
 Writer.prototype[TypeCode.STRING] = function writeString(value) {
-  this.writeCharacters(value, 'ascii');
+  this.writeCharacters(TypeCode.STRING, value);
 };
 
-Writer.prototype.writeCharacters = function writeCharacters(value, encoding) {
-  var type = encoding === 'ascii' ? TypeCode.STRING : TypeCode.NSTRING;
-  var length = Buffer.byteLength(value, encoding);
-  var buffer;
-  if (length <= 245) {
-    buffer = new Buffer(2 + length);
-    buffer[0] = type;
-    buffer[1] = length;
-    buffer.write(value, 2, length, encoding);
-  } else if (length <= 32767) {
-    buffer = new Buffer(4 + length);
-    buffer[0] = type;
-    buffer[1] = 246;
-    buffer.writeInt16LE(length, 2);
-    buffer.write(value, 4, length, encoding);
-  } else {
-    buffer = new Buffer(6 + length);
-    buffer[0] = type;
-    buffer[1] = 247;
-    buffer.writeInt32LE(length, 2);
-    buffer.write(value, 6, length, encoding);
+Writer.prototype.writeCharacters = function writeCharacters(type, value) {
+  if (typeof value !== 'string') {
+    throw new TypeError('Argument must be a string');
   }
-  this.push(buffer);
+
+  var encoded = util.convert.encode(value, this._useCesu8);
+  this.push(createBinaryOutBuffer(type, encoded));
 };
 
 Writer.prototype[TypeCode.BINARY] = function writeBinary(value) {

--- a/test/lib.Writer.js
+++ b/test/lib.Writer.js
@@ -209,6 +209,13 @@ describe('Lib', function () {
       writer.setValues([value]);
       writer.length.should.equal(length + 6);
       writer._buffers[0][1].should.equal(247);
+      // unicode char
+      value = 'ä';
+      length = value.length;
+      writer.setValues([value]);
+      writer.length.should.equal(4); 
+      writer._buffers[0][2].should.equal(0xC3);
+      writer._buffers[0][3].should.equal(0xA4);
     });
 
     it('should set a BINARY value', function () {


### PR DESCRIPTION
While executing prepared statement with SQL function and bind parameter:
"select * from "#TMP" where "EmployeeName" LIKE concat('%',concat(?,'%')) "
using char like 'ä' results in incorrect encoding -> wrong results.
The problem is that the parameter's metadata is returned as 'TypeCode.STRING' and the implementation was encoding it as ascii. According to protocol documentation strings should be encoded with cesu8.