### PR TITLE
Fix: no result sets when procedure called with large blob

### DIFF
--- a/lib/protocol/ExecuteTask.js
+++ b/lib/protocol/ExecuteTask.js
@@ -91,6 +91,7 @@ ExecuteTask.prototype.run = function run(next) {
       if (err) {
         return finalize(err);
       }
+      self.pushReply(reply);
       writeLob();
     });
   }
@@ -127,6 +128,11 @@ ExecuteTask.prototype.pushReply = function pushReply(reply) {
     } else {
       this.reply.rowsAffected = reply.rowsAffected;
     }
+  }
+  if (reply.resultSets && reply.resultSets.length) {
+    // old results sets should not be present as there is no bulk select or procedure execute
+    // still we keep them to be safe
+    this.reply.resultSets = [].concat(this.reply.resultSets || [], reply.resultSets);
   }
 };
 

--- a/test/acceptance/db.Lob.js
+++ b/test/acceptance/db.Lob.js
@@ -17,8 +17,12 @@
 var fs = require('fs');
 var path = require('path');
 var util = require('util');
+var crypto = require('crypto');
 var async = require('async');
 var db = require('../db')();
+var RemoteDB = require('../db/RemoteDB');
+
+var describeRemoteDB = db instanceof RemoteDB ? describe : describe.skip;
 
 if (!Buffer.prototype.equals) {
   Buffer.prototype.equals = function (buffer) {
@@ -38,7 +42,7 @@ if (!Buffer.prototype.equals) {
 }
 
 describe('db', function () {
-  this.timeout(5000);
+  this.timeout(50000);
 
   before(db.init.bind(db));
   after(db.end.bind(db));
@@ -172,7 +176,7 @@ describe('db', function () {
       });
   });
 
-  describe('HASH_BLOB', function() {
+  describeRemoteDB('HASH_BLOB', function() {
     var statement;
 
     before(function (done) {
@@ -202,7 +206,7 @@ describe('db', function () {
           rows.should.have.length(1);
           rows[0].should.eql({
             ALGO: 'MD5',
-            DIGEST: image.MD5.toUpperCase()
+            DIGEST: MD5(image.BDATA)
           });
           done();
         });
@@ -210,3 +214,9 @@ describe('db', function () {
     });
   });
 });
+
+function MD5(data) {
+  var hash = crypto.createHash('md5');
+  hash.update(data);
+  return hash.digest('hex').toUpperCase();
+}

--- a/test/acceptance/db.Lob.js
+++ b/test/acceptance/db.Lob.js
@@ -16,6 +16,7 @@
 
 var fs = require('fs');
 var path = require('path');
+var util = require('util');
 var async = require('async');
 var db = require('../db')();
 
@@ -37,13 +38,15 @@ if (!Buffer.prototype.equals) {
 }
 
 describe('db', function () {
+  this.timeout(5000);
+
   before(db.init.bind(db));
   after(db.end.bind(db));
+
   var client = db.client;
   var transaction = client._connection._transaction;
 
   describe('IMAGES', function () {
-    this.timeout(5000);
     before(db.createImages.bind(db));
     after(db.dropImages.bind(db));
 
@@ -167,6 +170,43 @@ describe('db', function () {
 
         async.waterfall([prepare, insert, validate], done);
       });
+  });
 
+  describe('HASH_BLOB', function() {
+    var statement;
+
+    before(function (done) {
+      async.series([
+        db.createHashBlobProc.bind(db),
+        client.prepare.bind(client, 'call HASH_BLOB (?)'),
+      ], function(err, results) {
+        statement = results[1];
+        done(err);
+      });
+    });
+
+    after(db.dropHashBlobProc.bind(db));
+
+    // call the procedure with images of different sizes
+    var images = require('../fixtures/images');
+    images.forEach(function(image) {
+      var title = util.format('should call the procedure with %s (%dB) and get its hash in a result set',
+        image.NAME, image.BDATA.length);
+      it(title, function(done) {
+        var params = [ image.BDATA ];
+        statement.exec(params, function(err, outParams, rows) {
+          if (err) {
+            return done(err);
+          }
+          arguments.should.have.length(3);
+          rows.should.have.length(1);
+          rows[0].should.eql({
+            ALGO: 'MD5',
+            DIGEST: image.MD5.toUpperCase()
+          });
+          done();
+        });
+      });
+    });
   });
 });

--- a/test/db/RemoteDB.js
+++ b/test/db/RemoteDB.js
@@ -154,7 +154,8 @@ RemoteDB.prototype.createHashBlobProc = function createHashBlobProc(cb) {
     'end'
   ].join('\n');
   var self = this;
-  self.client.exec('drop procedure HASH_BLOB cascade', function() {
+  self.dropHashBlobProc(function() {
+    // ignore any error as the procedure may not exists yet
     self.client.exec(create, cb);
   });
 }

--- a/test/db/RemoteDB.js
+++ b/test/db/RemoteDB.js
@@ -155,7 +155,7 @@ RemoteDB.prototype.createHashBlobProc = function createHashBlobProc(cb) {
   ].join('\n');
   var self = this;
   self.dropHashBlobProc(function() {
-    // ignore any error as the procedure may not exists yet
+    // ignore any error as the procedure may not exist yet
     self.client.exec(create, cb);
   });
 }

--- a/test/db/RemoteDB.js
+++ b/test/db/RemoteDB.js
@@ -144,3 +144,21 @@ RemoteDB.prototype.dropConcatStringsProc = function dropConcatStringsProc(cb) {
   var sql = 'drop procedure CONCAT_STRINGS_PROC cascade';
   this.client.exec(sql, cb);
 };
+
+RemoteDB.prototype.createHashBlobProc = function createHashBlobProc(cb) {
+  var create = [
+    'create procedure HASH_BLOB (in image BLOB)',
+    'language sqlscript reads sql data as',
+    'begin',
+    '  select \'MD5\' as ALGO, TO_VARCHAR(HASH_MD5(TO_VARBINARY(image))) as DIGEST from dummy;',
+    'end'
+  ].join('\n');
+  var self = this;
+  self.client.exec('drop procedure HASH_BLOB cascade', function() {
+    self.client.exec(create, cb);
+  });
+}
+
+RemoteDB.prototype.dropHashBlobProc = function dropHashBlobProc(cb) {
+  this.client.exec('drop procedure HASH_BLOB cascade', cb);
+};

--- a/test/db/TestDB.js
+++ b/test/db/TestDB.js
@@ -80,6 +80,14 @@ TestDB.prototype.dropConcatStringsProc = function dropConcatStringsProc(cb) {
   doNothing(cb);
 };
 
+TestDB.prototype.createHashBlobProc = function createHashBlobProc(cb) {
+  doNothing(cb);
+};
+
+TestDB.prototype.dropHashBlobProc = function dropHashBlobProc(cb) {
+  doNothing(cb);
+};
+
 
 function doNothing(done) {
   process.nextTick(done);

--- a/test/fixtures/images.js
+++ b/test/fixtures/images.js
@@ -15,8 +15,9 @@
 
 var fs = require('fs');
 var path = require('path');
+var crypto = require('crypto');
 
-module.exports = [{
+var images = [{
   NAME: 'lobby.jpg',
   BDATA: fs.readFileSync(path.join(__dirname, 'img', 'lobby.jpg'))
 }, {
@@ -29,3 +30,11 @@ module.exports = [{
   NAME: 'sap.jpg',
   BDATA: fs.readFileSync(path.join(__dirname, 'img', 'sap.jpg'))
 }];
+
+images.forEach(function(img) {
+  var hash = crypto.createHash('md5');
+  hash.update(img.BDATA);
+  img.MD5 = hash.digest('hex');
+});
+
+module.exports = images;

--- a/test/fixtures/images.js
+++ b/test/fixtures/images.js
@@ -15,9 +15,8 @@
 
 var fs = require('fs');
 var path = require('path');
-var crypto = require('crypto');
 
-var images = [{
+module.exports = [{
   NAME: 'lobby.jpg',
   BDATA: fs.readFileSync(path.join(__dirname, 'img', 'lobby.jpg'))
 }, {
@@ -30,11 +29,3 @@ var images = [{
   NAME: 'sap.jpg',
   BDATA: fs.readFileSync(path.join(__dirname, 'img', 'sap.jpg'))
 }];
-
-images.forEach(function(img) {
-  var hash = crypto.createHash('md5');
-  hash.update(img.BDATA);
-  img.MD5 = hash.digest('hex');
-});
-
-module.exports = images;

--- a/test/lib.ExecuteTask.js
+++ b/test/lib.ExecuteTask.js
@@ -182,10 +182,10 @@ describe('Lib', function () {
           }]
         }, {
           type: MessageType.WRITE_LOB,
-          args: [null]
+          args: [null, {}]
         }, {
           type: MessageType.COMMIT,
-          args: [null]
+          args: [null, {}]
         }]
       }, function done(err, reply) {
         (!err).should.be.ok;

--- a/test/lib.ExecuteTask.js
+++ b/test/lib.ExecuteTask.js
@@ -218,7 +218,7 @@ describe('Lib', function () {
       }).run(next);
     });
 
-    it('should push a reply', function () {
+    it('should accumulate rows affected', function () {
       var task = createExecuteTask();
       task.pushReply({});
       task.pushReply({
@@ -229,6 +229,19 @@ describe('Lib', function () {
         rowsAffected: [1, 1]
       });
       task.reply.rowsAffected.should.eql([1, 1, 1]);
+    });
+
+    it('should accumulate result sets', function () {
+      var task = createExecuteTask();
+      task.pushReply({});
+      task.pushReply({
+        resultSets: [{}]
+      });
+      task.reply.resultSets.should.have.length(1);
+      task.pushReply({
+        resultSets: [{}, {}]
+      });
+      task.reply.resultSets.should.have.length(3);
     });
 
     it('should getParameters with invalid values error', function (done) {


### PR DESCRIPTION
When a procedure is called with a LOB larger than the packet size (128KB) HANA returns the description of the procedure result sets in the reply to the last WRITE_LOB command, not the EXECUTE command reply.
Timeout increased to allow for testing via VPN.