### PR TITLE
Fix error message typo

### DIFF
--- a/lib/protocol/ExecuteTask.js
+++ b/lib/protocol/ExecuteTask.js
@@ -167,7 +167,7 @@ ExecuteTask.prototype.getParameters = function getParameters(availableSize, cb) 
         ++row;
         self.writer.setValues(self.parameterValues.shift());
       } catch (err) {
-        return cb(new Error('Cannon set parameter at row: ' + row + '. ' + err.message));
+        return cb(new Error('Cannot set parameter at row: ' + row + '. ' + err.message));
       }
     }
     var remainingSize = availableSize - bytesWritten;

--- a/test/lib.ExecuteTask.js
+++ b/test/lib.ExecuteTask.js
@@ -251,7 +251,7 @@ describe('Lib', function () {
         throw invalidValuesError;
       };
       task.getParameters(64, function (err) {
-        err.message.should.equal('Cannon set parameter at row: 1. ' + invalidValuesError.message);
+        err.message.should.equal('Cannot set parameter at row: 1. ' + invalidValuesError.message);
         done();
       });
     });


### PR DESCRIPTION
Replaced "Cannon" with "Cannot". Small thing.