### PR TITLE
Remove buffers `noAssert` argument

### DIFF
--- a/lib/protocol/Reader.js
+++ b/lib/protocol/Reader.js
@@ -35,7 +35,7 @@ Reader.prototype.readTinyInt = function readTinyInt() {
   if (this.buffer[this.offset++] === 0x00) {
     return null;
   }
-  var value = this.buffer.readUInt8(this.offset, true);
+  var value = this.buffer.readUInt8(this.offset);
   this.offset += 1;
   return value;
 };
@@ -44,7 +44,7 @@ Reader.prototype.readSmallInt = function readSmallInt() {
   if (this.buffer[this.offset++] === 0x00) {
     return null;
   }
-  var value = this.buffer.readInt16LE(this.offset, true);
+  var value = this.buffer.readInt16LE(this.offset);
   this.offset += 2;
   return value;
 };
@@ -53,7 +53,7 @@ Reader.prototype.readInt = function readInt() {
   if (this.buffer[this.offset++] === 0x00) {
     return null;
   }
-  var value = this.buffer.readInt32LE(this.offset, true);
+  var value = this.buffer.readInt32LE(this.offset);
   this.offset += 4;
   return value;
 };
@@ -81,11 +81,11 @@ Reader.prototype.readBytes = function readBytes(isString) {
     case 0xff:
       return null;
     case 0xf6:
-      length = this.buffer.readInt16LE(this.offset, true);
+      length = this.buffer.readInt16LE(this.offset);
       this.offset += 2;
       break;
     case 0xf7:
-      length = this.buffer.readInt32LE(this.offset, true);
+      length = this.buffer.readInt32LE(this.offset);
       this.offset += 4;
       break;
     default:
@@ -137,7 +137,7 @@ Reader.prototype.readTime = function readTime() {
   }
   var min = this.buffer[this.offset + 1];
   this.offset += 2;
-  var msec = this.buffer.readUInt16LE(this.offset, true);
+  var msec = this.buffer.readUInt16LE(this.offset);
   this.offset += 2;
   // msb set ==> not null
   // unset msb
@@ -163,7 +163,7 @@ Reader.prototype.readTimestamp = function readTimestamp() {
 };
 
 Reader.prototype.readDayDate = function readDayDate() {
-  var value = this.buffer.readInt32LE(this.offset, true);
+  var value = this.buffer.readInt32LE(this.offset);
   this.offset += 4;
   if (value === 3652062 || value === 0) {
     return null;
@@ -172,7 +172,7 @@ Reader.prototype.readDayDate = function readDayDate() {
 };
 
 Reader.prototype.readSecondTime = function readSecondTime() {
-  var value = this.buffer.readInt32LE(this.offset, true);
+  var value = this.buffer.readInt32LE(this.offset);
   this.offset += 4;
   if (value === 86402 || value === 0) {
     return null;
@@ -245,7 +245,7 @@ Reader.prototype.readLob = function readLob(type) {
   var locatorId = this.buffer.slice(this.offset, this.offset + 8);
   this.offset += 8;
   // offset 28
-  var chunkLength = this.buffer.readInt32LE(this.offset, true);
+  var chunkLength = this.buffer.readInt32LE(this.offset);
   this.offset += 4;
   // offset 32
   var chunk = null;
@@ -272,7 +272,7 @@ Reader.prototype.readDouble = function readDouble() {
     this.offset += 8;
     return null;
   }
-  var value = this.buffer.readDoubleLE(this.offset, true);
+  var value = this.buffer.readDoubleLE(this.offset);
   this.offset += 8;
   return value;
 };
@@ -285,7 +285,7 @@ Reader.prototype.readFloat = function readFloat() {
     this.offset += 4;
     return null;
   }
-  var value = this.buffer.readFloatLE(this.offset, true);
+  var value = this.buffer.readFloatLE(this.offset);
   this.offset += 4;
   return value;
 };


### PR DESCRIPTION
Support for the `noAssert` argument dropped in the upcoming Node.js
v.10. This removes the argument to make sure everything works as it
should.

Refs: https://github.com/nodejs/node/pull/18395