### PR TITLE
Fix missing row of parameters during batch insert

### DIFF
--- a/lib/protocol/ExecuteTask.js
+++ b/lib/protocol/ExecuteTask.js
@@ -67,7 +67,7 @@ ExecuteTask.prototype.run = function run(next) {
   }
 
   function execute() {
-    if (!self.parameterValues.length) {
+    if (!self.parameterValues.length && !self.writer.hasParameters) {
       return finalize();
     }
     self.sendExecute(function receive(err, reply) {
@@ -161,10 +161,10 @@ ExecuteTask.prototype.getParameters = function getParameters(availableSize, cb) 
   }
 
   function next() {
-    if (!self.parameterValues.length) {
-      return cb(null, args);
-    }
     if (!self.writer.hasParameters) {
+      if (!self.parameterValues.length) {
+        return cb(null, args);
+      }
       try {
         ++row;
         self.writer.setValues(self.parameterValues.shift());


### PR DESCRIPTION
Bug: 288040
A row of parameters could have gone missing during a batch insert if there was
insufficient space in the packet. This fix adds an additional check for
outstanding parameters so they'll no longer be excluded.