### PR TITLE
Fix offset calculation for NCLOB data containing non-BMP characters

### DIFF
--- a/lib/protocol/Lob.js
+++ b/lib/protocol/Lob.js
@@ -71,7 +71,7 @@ function Lob(readLob, ld, options) {
 
 function textChunkLength(chunk, useCesu8) {
   return (useCesu8) ?
-    util.convert.lengthInCesu8(chunk) :
+    util.convert.lengthInCesu8(chunk, false) :
     chunk.toString('utf-8').length;
 }
 

--- a/lib/util/convert.js
+++ b/lib/util/convert.js
@@ -18,15 +18,19 @@ function decode(buffer, useCesu8) {
     buffer.toString('utf-8');
 }
 
-function lengthInCesu8(buffer) {
+function lengthInCesu8(buffer, combineSurrogates = true) {
   var text = iconv.decode(buffer, 'cesu8');
-
-  // count surrogate parts as single char (String.lenght counts it as 2)
-  var count = 0, code;
-  for (var i = 0; i < text.length; i++) {
-    code = text.charCodeAt(i);
-    if (0xD800 <= code && code <= 0xDBFF) { i++; }
-    count++;
+  var len = 0;
+  if (combineSurrogates) {
+    // count surrogate pairs as a single char (String.length counts it as 2)
+    var code = 0;
+    for (var i = 0; i < text.length; i++) {
+      code = text.charCodeAt(i);
+      if (0xD800 <= code && code <= 0xDBFF) { i++; }
+      len++;
+    }
+  } else {
+    len = text.length;
   }
-  return count;
+  return len;
 }

--- a/test/lib.Lob.js
+++ b/test/lib.Lob.js
@@ -176,7 +176,7 @@ describe('Lib', function () {
       var lob = new Lob(readLob, createLobDescriptor(LobSourceType.NCLOB, chunk, 1), { useCesu8: true });
       lob.length.should.equal(1);
       lob.increaseOffset(chunk);
-      lob._offset.should.equal(2);
+      lob._offset.should.equal(3);
     });
 
     it('should create a Lob with type CLOB', function () {
@@ -199,7 +199,7 @@ describe('Lib', function () {
       var lob = new Lob(readLob, ld, { useCesu8: true, useDefaultType: true });
       lob.length.should.equal(1);
       lob.increaseOffset(chunk);
-      lob._offset.should.equal(2);
+      lob._offset.should.equal(3);
     });
 
     function createLobDescriptor(type, chunk, charLength) {

--- a/test/util.convert.js
+++ b/test/util.convert.js
@@ -40,8 +40,12 @@ describe('Util', function () {
       util.convert.decode(outOfBomCesuBuffer, true).should.eql(outOfBom);
     });
 
-    it('should count cesu8 charactes in cesu8 encoded buffer', function () {
+    it('should count cesu8 characters in cesu8 encoded buffer', function () {
       util.convert.lengthInCesu8(outOfBomCesuBuffer).should.equal(1);
+    });
+
+    it('should count cesu8 surrogates in cesu8 encoded buffer', function () {
+      util.convert.lengthInCesu8(outOfBomCesuBuffer, false).should.equal(2);
     });
 
   });


### PR DESCRIPTION
The driver was counting CESU-8 surrogate pairs as a single character when calculating offset values for READLOB requests. However, the server expects these to count as two characters.