### PR TITLE
Fix discarded enqueued queries

### DIFF
--- a/lib/protocol/Connection.js
+++ b/lib/protocol/Connection.js
@@ -268,6 +268,7 @@ Connection.prototype._addListeners = function _addListeners(socket) {
   function onend() {
     var err = new Error('Connection closed by server');
     err.code = 'EHDBCLOSE';
+    self._clearQueue(err);
     onerror(err);
   }
   socket.on('end', onend);
@@ -276,8 +277,12 @@ Connection.prototype._addListeners = function _addListeners(socket) {
 Connection.prototype._cleanup = function _cleanup() {
   this._socket = undefined;
   this._state = undefined;
+  this._clearQueue()
+};
+
+Connection.prototype._clearQueue = function _clearQueue(err) {
   if (this._queue) {
-    this._queue.abort();
+    this._queue.abort(err);
     this._queue = undefined;
   }
 };

--- a/lib/util/Queue.js
+++ b/lib/util/Queue.js
@@ -63,7 +63,8 @@ Queue.prototype.pause = function pause() {
   return this;
 };
 
-Queue.prototype.abort = function abort() {
+Queue.prototype.abort = function abort(err) {
+  this.queue.forEach(t => t.receive(err))
   this.queue = [];
   this.busy = false;
   this.running = false;


### PR DESCRIPTION
## Description

Currently it is possible to have `Task`s which are queued while the database connection is in the process of being disconnected from the database. As the running `Task` is being rejected by the `onend` event it will trigger the next `Task`. This task is removed from the queue and send to the connection. Resulting in the connection becoming dormant and the started `Task` hanging. Additionally all queued `Task`s are completely discarded when `onclose` is called. Which makes all the enqueued `Task`s hang.

## Visual examples

The current behavior:

```mermaid
sequenceDiagram
participant Connection
participant Queue
participant HANA

Connection->>Queue: Task 1
Connection->>Queue: Task 2
Queue->>Connection: run 1
Connection->>HANA: Task 1
HANA-->>Connection: Disconnect
Connection->>Queue: Task 1 (Error)
Queue->>Queue: next
Queue->>Connection: run 2
Connection->>HANA: Task 2
Connection->>Connection: Update Socket status
```

The behavior of the PR:

```mermaid
sequenceDiagram
participant Connection
participant Queue
participant HANA

Connection->>Queue: Task 1
Connection->>Queue: Task 2
Queue->>Connection: run 1
Connection->>HANA: Task 1
HANA-->>Connection: Disconnect
Connection->>Queue: Abort (Error)
Queue->>Queue: Task 2 (Error)
Connection->>Queue: Task 1 (Error)
Connection->>Connection: Update Socket Status
```

Alternative solution would be to call run in the next of the queue with `setImmediate`, but this might come with an performance impact for positive connection scenarios.

```mermaid
sequenceDiagram
participant Connection
participant Queue
participant HANA

Connection->>Queue: Task 1
Connection->>Queue: Task 2
Queue->>Connection: run 1
Connection->>HANA: Task 1
HANA-->>Connection: Disconnect
Connection->>Queue: Task 1 (Error)
Queue->>Queue: next (setImmediate)
Connection->>Connection: Update Socket Status
Queue->>Connection: run 2
Connection->>Queue: Task 2 (Error)
```