### PR TITLE
Raise error if _queue undefined in enqueue

### DIFF
--- a/lib/protocol/Connection.js
+++ b/lib/protocol/Connection.js
@@ -398,7 +398,7 @@ Connection.prototype.receive = function receive(buffer, cb) {
 Connection.prototype.enqueue = function enqueue(task, cb) {
   var queueable;
 
-  if (!this._socket) {
+  if (!this._socket || !this._queue) {
     var err = new Error('Connection closed');
     err.code = 'EHDBCLOSE';
     return cb(err);


### PR DESCRIPTION
In Connection.enqueue, check if the internal task queue is undefined (i.e. the underlying socket has emitted an 'end' event and the queue has been cleaned up).

Bug: 315347