### PR TITLE
Ensure client.exec callback is called if client is closed

### DIFF
--- a/lib/protocol/Connection.js
+++ b/lib/protocol/Connection.js
@@ -398,7 +398,7 @@ Connection.prototype.receive = function receive(buffer, cb) {
 Connection.prototype.enqueue = function enqueue(task, cb) {
   var queueable;
 
-  if (!this._socket || !this._queue) {
+  if (!this._socket || !this._queue || this.readyState === 'closed') {
     var err = new Error('Connection closed');
     err.code = 'EHDBCLOSE';
     return cb(err);


### PR DESCRIPTION
Previously with Node.js v16+, the callback for client.exec could be ignored (not called) if exec was called after client.close(). Fixed so the callback is called with the appropriate error.