### PR TITLE
Fix hang when read stream error occurs

### DIFF
--- a/lib/protocol/Writer.js
+++ b/lib/protocol/Writer.js
@@ -102,6 +102,16 @@ Writer.prototype.finializeParameters = function finializeParameters(
   var self = this;
   var stream, header;
 
+  this._lobs.forEach((stream) => {
+    if (stream._readableState.errored) {
+      cb(stream._readableState.errored);
+      return;
+    }
+    stream.once('error', function (err) {
+      stream._errored = err;
+    });
+  });
+
   function finalize() {
     /* jshint bitwise:false */
     // update lob options in header
@@ -171,7 +181,7 @@ Writer.prototype.finializeParameters = function finializeParameters(
     if (!self._lobs.length || bytesRemaining <= 0) {
       return cb(null);
     }
-    // set reabable stream
+    // set readable stream
     stream = self._lobs[0];
     // set lob header
     header = stream._header;
@@ -211,6 +221,11 @@ Writer.prototype.finalizeWriteLobRequest = function finalizeWriteLobRequest(
   bytesRemaining, cb) {
   var self = this;
   var stream, header;
+
+  if (this._lobs.length && this._lobs[0]._errored) {
+      cb(this._lobs[0]._errored);
+      return;
+  }
 
   function cleanup() {
     // remove event listeners

--- a/lib/protocol/Writer.js
+++ b/lib/protocol/Writer.js
@@ -97,19 +97,25 @@ Writer.prototype.add = function add(type, value) {
   }
 };
 
+function storeErrorOnStream (err) {
+  this._errored = err;
+}
+
 Writer.prototype.finializeParameters = function finializeParameters(
   bytesRemaining, cb) {
   var self = this;
   var stream, header;
+  this._streamErrorListeners = [];
 
   this._lobs.forEach((stream) => {
     if (stream._readableState.errored) {
       cb(stream._readableState.errored);
       return;
     }
-    stream.once('error', function (err) {
-      stream._errored = err;
-    });
+    var errorListener = storeErrorOnStream.bind(stream);
+    self._streamErrorListeners.push(errorListener); // keep track so it can
+                                                    // be removed later
+    stream.once('error', errorListener);
   });
 
   function finalize() {
@@ -117,6 +123,10 @@ Writer.prototype.finializeParameters = function finializeParameters(
     // update lob options in header
     header[1] |= LobOptions.LAST_DATA;
     // remove current lob from stack
+    if(self._streamErrorListeners && self._streamErrorListeners.length) {
+      stream.removeListener('error', self._streamErrorListeners[0]);
+      self._streamErrorListeners.shift();
+    }
     self._lobs.shift();
   }
 
@@ -248,6 +258,10 @@ Writer.prototype.finalizeWriteLobRequest = function finalizeWriteLobRequest(
     // update lob options in header
     header[8] |= LobOptions.LAST_DATA;
     // remove current lob from stack
+    if(self._streamErrorListeners && self._streamErrorListeners.length) {
+      stream.removeListener('error', self._streamErrorListeners[0]);
+      self._streamErrorListeners.shift();
+    }
     self._lobs.shift();
   }
 

--- a/lib/protocol/Writer.js
+++ b/lib/protocol/Writer.js
@@ -222,10 +222,12 @@ Writer.prototype.finalizeWriteLobRequest = function finalizeWriteLobRequest(
   var self = this;
   var stream, header;
 
-  if (this._lobs.length && this._lobs[0]._errored) {
-      cb(this._lobs[0]._errored);
+  this._lobs.forEach((stream) => {
+    if (stream._errored) {
+      cb(stream._errored);
       return;
-  }
+    }
+  });
 
   function cleanup() {
     // remove event listeners


### PR DESCRIPTION
Fixes potential hangs when read stream errors occur for LOB parameters. In particular, these hangs could have happened when stream read errors occur between writeLOB chunks or before the parameter is bound.

Bug: 316072