### PR TITLE
Use `Array.isArray` instead of `util.isArray`

### DIFF
--- a/lib/protocol/Connection.js
+++ b/lib/protocol/Connection.js
@@ -481,7 +481,7 @@ Connection.prototype.connect = function connect(options, cb) {
     if (err) {
       return cb(err);
     }
-    if (util.isArray(reply.connectOptions)) {
+    if (Array.isArray(reply.connectOptions)) {
       self.connectOptions.setOptions(reply.connectOptions);
     }
     manager.finalize(reply.authentication);

--- a/lib/protocol/MessageBuffer.js
+++ b/lib/protocol/MessageBuffer.js
@@ -48,7 +48,7 @@ MessageBuffer.prototype.push = function push(chunk) {
 };
 
 MessageBuffer.prototype.getData = function getData() {
-  if (util.isArray(this.data)) {
+  if (Array.isArray(this.data)) {
     return Buffer.concat(this.data, this.length);
   }
   return this.data;

--- a/lib/protocol/Statement.js
+++ b/lib/protocol/Statement.js
@@ -71,7 +71,7 @@ Statement.prototype.drop = function drop(cb) {
 };
 
 Statement.prototype.getParameterName = function getParameterName(i) {
-  if (util.isArray(this.parameterMetadata) && i < this.parameterMetadata.length) {
+  if (Array.isArray(this.parameterMetadata) && i < this.parameterMetadata.length) {
     return this.parameterMetadata[i].name;
   }
 };
@@ -84,7 +84,7 @@ Statement.prototype.handle = function handle(err, reply, cb) {
 
   this.id = reply.statementId;
   this.functionCode = reply.functionCode;
-  if (util.isArray(reply.resultSets) && reply.resultSets.length) {
+  if (Array.isArray(reply.resultSets) && reply.resultSets.length) {
     this.resultSetMetadata = reply.resultSets[0].metadata;
   }
   this.parameterMetadata = reply.parameterMetadata;

--- a/lib/protocol/Stringifier.js
+++ b/lib/protocol/Stringifier.js
@@ -38,7 +38,7 @@ function Stringifier(options) {
 }
 
 Stringifier.prototype._transform = function _transform(thing, encoding, done) {
-  if (util.isArray(thing) && thing.length) {
+  if (Array.isArray(thing) && thing.length) {
     this.push(this.transformRows(thing));
   } else {
     this.push(this.transformRow(thing));

--- a/lib/protocol/data/Fields.js
+++ b/lib/protocol/data/Fields.js
@@ -14,7 +14,6 @@
 'use strict';
 
 const common = require('../../protocol/common');
-var util = require('../../util');
 
 exports.read = read;
 exports.write = write;
@@ -81,7 +80,7 @@ function write(part, fields) {
     field = fields[i];
     if (Buffer.isBuffer(field)) {
       data = field;
-    } else if (util.isArray(field)) {
+    } else if (Array.isArray(field)) {
       data = write({}, field).buffer;
     } else {
       data = new Buffer(field, 'ascii');
@@ -133,7 +132,7 @@ function getArgumentCount(fields) {
 function getByteLengthOfField(field) {
   if (Buffer.isBuffer(field)) {
     return field.length;
-  } else if (util.isArray(field)) {
+  } else if (Array.isArray(field)) {
     return getByteLength(field);
   }
   return Buffer.byteLength(field, 'ascii');

--- a/lib/protocol/part/AbstractOptions.js
+++ b/lib/protocol/part/AbstractOptions.js
@@ -40,7 +40,7 @@ AbstractOptions.prototype.getOptions = function getOptions() {
 AbstractOptions.prototype.setOptions = function setOptions(options) {
   var self = this;
 
-  if (!util.isArray(options)) {
+  if (!Array.isArray(options)) {
     return;
   }
 

--- a/lib/protocol/reply/Segment.js
+++ b/lib/protocol/reply/Segment.js
@@ -170,7 +170,7 @@ Reply.prototype.add = function add(part) {
     this.addResultSetFragment(name, value);
   } else if (util.isUndefined(this[name])) {
     this[name] = value;
-  } else if (util.isArray(this[name])) {
+  } else if (Array.isArray(this[name])) {
     this[name].push(value);
   } else {
     var existingValue = this[name];

--- a/lib/util/index.js
+++ b/lib/util/index.js
@@ -216,7 +216,7 @@ function proxyEvents(source, target, events) {
 exports.proxyEvents = proxyEvents;
 
 function createReadStream(ds, events, options) {
-  if (!util.isArray(events)) {
+  if (!Array.isArray(events)) {
     options = events;
     events = ['error', 'close'];
   }


### PR DESCRIPTION
Hi, we're currently getting this deprecation warning in our CAP server logs coming from `hdb` with Node 22:

```
(node:95002) [DEP0044] DeprecationWarning: The `util.isArray` API is deprecated. Please use `Array.isArray()` instead.
(Use `node --trace-deprecation ...` to show where the warning was created)
```

This PR replaces all `util.isArray` by `Array.isArray`. Node 22 becomes active LTS very soon and this fix is compatible with older Node.js versions.