### PR TITLE
Fixed 2 integration tests

### DIFF
--- a/test/acceptance/db.Prepare.js
+++ b/test/acceptance/db.Prepare.js
@@ -40,8 +40,8 @@ describe('db', function () {
               var p = metadata[0];
               p.should.have.property('mode', 2);
               // on HANA SP12 dataType = 9 (VARCHAR1)
-              // on HANA2 dataType = 29 (STRING)
-              p.should.have.property('dataType').which.is.oneOf(9, 29);
+              // on HANA2 dataType = 29 (STRING) or 30 (NSTRING)
+              p.should.have.property('dataType').which.is.oneOf(9, 29, 30);
               p.should.have.property('ioType', 1);
               callback(null, statement);
             });

--- a/test/acceptance/db.Query.js
+++ b/test/acceptance/db.Query.js
@@ -20,6 +20,7 @@ var Readable = stream.Readable;
 var Writable = stream.Writable;
 var ResultSet = lib.ResultSet;
 var db = require('../db')();
+var RemoteDB = require('../db/RemoteDB');
 
 describe('db', function () {
   before(db.init.bind(db));
@@ -120,18 +121,40 @@ describe('db', function () {
         after(db.dropReadNumbersProc.bind(db));
 
         it('should return the numbers between 3 and 5', function (done) {
-          var sql =
-            'select * from READ_NUMBERS_BETWEEN_VIEW with parameters (' +
-            '\'placeholder\' = (\'$$a$$\', \'3\'),' +
-            '\'placeholder\' = (\'$$b$$\', \'5\'))';
-          client.exec(sql, function (err, rows) {
+          function testOnPremise() {
+            var sql =
+              'select * from READ_NUMBERS_BETWEEN_VIEW with parameters (' +
+              '\'placeholder\' = (\'$$a$$\', \'3\'),' +
+              '\'placeholder\' = (\'$$b$$\', \'5\'))';
+            client.exec(sql, validateResult);
+          }
+
+          function testCloud() {
+            var sql = 'SELECT * FROM READ_NUMBERS_BETWEEN_FUNC (placeholder."A"=>\'3\', placeholder."B"=>\'5\')';
+            client.exec(sql, validateResult);
+          }
+
+          function validateResult(err, rows) {
             if (err) {
               return done(err);
             }
             rows.should.have.length(3);
             rows.should.eql(db.numbers.slice(3, 6));
             done();
-          });
+          }
+
+          if (db instanceof RemoteDB) {
+            db.getHanaBuildVersion(function (version) {
+              if (version !== undefined && version.startsWith("4.5")) { // HANA Cloud
+                testCloud();
+              } else {
+                testOnPremise();
+              }
+            })
+          } else {
+            // Mock server models on premise
+            testOnPremise();
+          }
         });
       });
 


### PR DESCRIPTION
- In HANA Cloud, SQL used in the 'createReadNumbersProc' testing setup is not supported, so the SQL was changed when run on HANA cloud.
- Also modified 'direct execute of ProcView with parameters' test to match the new change above for HANA cloud.
- Also updated 'should return all numbers like &#96;b&#96;' test metadata data type to match those from the HANA database.
- When not running on HANA cloud, the behaviour and SQL executed is the same as before.