### PR TITLE
Fixed blob insert with stream.Readable hanging

### DIFF
--- a/lib/protocol/Writer.js
+++ b/lib/protocol/Writer.js
@@ -15,6 +15,7 @@
 
 var util = require('../util');
 var Readable = util.stream.Readable;
+var Transform = util.stream.Transform;
 var common = require('./common');
 var TypeCode = common.TypeCode;
 var LobOptions = common.LobOptions;
@@ -133,6 +134,10 @@ Writer.prototype.finializeParameters = function finializeParameters(
       stream.removeListener('error', self._streamErrorListeners[0]);
       self._streamErrorListeners.shift();
     }
+    if (stream instanceof LobTransform) {
+      // Destory wrapping stream
+      stream.destroy();
+    }
     self._lobs.shift();
   }
 
@@ -163,23 +168,32 @@ Writer.prototype.finializeParameters = function finializeParameters(
     /* jshint validthis:true */
     var chunk = this.read(bytesRemainingForLOBs);
     if (chunk === null) {
-      chunk = this.read();
-    }
-    if (chunk === null) {
       return;
     }
-    if (chunk.length > bytesRemainingForLOBs) {
-      cleanup();
-      return cb(createReadStreamError());
+    // store lob length in header
+    var length = header.readInt32LE(2);
+    // readable events might not emit for every chunk so we handle all
+    // avaliable chunks immediately
+    while (chunk !== null) {
+      if (chunk.length > bytesRemainingForLOBs) {
+        cleanup();
+        return cb(createReadStreamError());
+      }
+      // increase lob length
+      length += chunk.length;
+      // push chunk
+      self.push(chunk);
+      bytesRemainingForLOBs -= chunk.length;
+      // stop appending if there is no remaining space
+      if (bytesRemainingForLOBs === 0) {
+        break;
+      }
+      
+      chunk = this.read(bytesRemainingForLOBs);
     }
     // update lob length in header
-    var length = header.readInt32LE(2);
-    length += chunk.length;
     header.writeInt32LE(length, 2);
-    // push chunk
-    self.push(chunk);
-    bytesRemainingForLOBs -= chunk.length;
-    // stop appending if there is no remaining space
+
     if (bytesRemainingForLOBs === 0) {
       cleanup();
       // finalize lob if the stream has already ended
@@ -268,6 +282,10 @@ Writer.prototype.finalizeWriteLobRequest = function finalizeWriteLobRequest(
       stream.removeListener('error', self._streamErrorListeners[0]);
       self._streamErrorListeners.shift();
     }
+    if (stream instanceof LobTransform) {
+      // Destory wrapping stream
+      stream.destroy();
+    }
     self._lobs.shift();
   }
 
@@ -284,23 +302,32 @@ Writer.prototype.finalizeWriteLobRequest = function finalizeWriteLobRequest(
     /* jshint validthis:true */
     var chunk = this.read(bytesRemaining);
     if (chunk === null) {
-      chunk = this.read();
-    }
-    if (chunk === null) {
       return;
     }
-    if (chunk.length > bytesRemaining) {
-      cleanup();
-      return cb(createReadStreamError());
-    }
-    // update lob length in buffer
+    // store lob length in header
     var length = header.readInt32LE(17);
-    length += chunk.length;
+    // readable events might not emit for every chunk so we handle all
+    // avaliable chunks immediately
+    while (chunk !== null) {
+      if (chunk.length > bytesRemaining) {
+        cleanup();
+        return cb(createReadStreamError());
+      }
+      // increase lob length
+      length += chunk.length;
+      // push chunk
+      self.push(chunk);
+      bytesRemaining -= chunk.length;
+      // stop appending if there is no remaining space
+      if (bytesRemaining === 0) {
+        break;
+      }
+      
+      chunk = this.read(bytesRemaining);
+    }
+    // update lob length in header
     header.writeInt32LE(length, 17);
-    // push chunk
-    self.push(chunk);
-    bytesRemaining -= chunk.length;
-    // stop appending if there is no remaining space
+
     if (bytesRemaining === 0) {
       cleanup();
       // finalize lob if the stream has already ended
@@ -416,7 +443,13 @@ Writer.prototype.pushLob = function pushLob(buffer, value) {
     stream.push(value);
     stream.push(null);
   } else if (value instanceof Readable) {
-    stream = value;
+    if (value.readableObjectMode) {
+      // Wrap the stream with another stream with objectMode false, so that a given 
+      // number of bytes can be read at a time not each object
+      stream = new LobTransform(value, ['error'], { objectMode: false });
+    } else {
+      stream = value;
+    }
   } else if (value.readable === true) {
     stream = new Readable().wrap(value);
   } else {
@@ -878,4 +911,33 @@ function createBinaryOutBuffer(type, value) {
     value.copy(buffer, 6);
   }
   return buffer;
+}
+
+util.inherits(LobTransform, Transform);
+
+// Wraps a Readable stream with a stream that is not in object mode
+function LobTransform(source, events, options) {
+  this._source = source;
+  Transform.call(this, options);
+  // Forward all events indicated to the LobTransform wrapper
+  this._proxiedEvents = [];
+  for (var event of events) {
+    var listener = this.emit.bind(this, event);
+    source.on(event, listener);
+    this._proxiedEvents.push({eventName: event, listener: listener});
+  }
+  source.pipe(this);
+}
+
+LobTransform.prototype._transform = function _transform(chunk, encoding, cb) {
+  this.push(chunk);
+  cb();
+}
+
+LobTransform.prototype._destroy = function _destroy() {
+  var self = this;
+  this._proxiedEvents.forEach(function (value) {
+    self._source.removeListener(value.eventName, value.listener);
+  });
+  this._source.unpipe(this);
 }

--- a/test/lib.Writer.js
+++ b/test/lib.Writer.js
@@ -301,8 +301,64 @@ describe('Lib', function () {
         done();
       });
     });
+    
+    it('should get Parameters where multiple chunks are taken',
+      function(done) {
+        var writer = new Writer([TypeCode.BLOB]);
+        var stream = lib.util.stream.Readable.from([Buffer.from("1", "ascii"), Buffer.from("2", "ascii"),
+          Buffer.from("3", "ascii"), Buffer.from("4", "ascii")]);
+        var size = 14; // 10 for header, and 4 for buffer
+        writer.setValues([stream]);
+        writer.getParameters(size, function (err, buffer) {
+          buffer.should.have.length(size);
+          buffer.slice(10).toString('ascii').should.equal(
+            '1234');
+            stream.listenerCount('readable').should.equal(0);
+            // When the buffer exactly fits like here, there must be another write lob
+            // request where the stream is closed and the error listener to forward 
+            // errors is removed
+            stream.listenerCount('error').should.equal(1);
+            stream.listenerCount('end').should.equal(0);
+          done();
+        });
+      });
 
-    it('should get WriteLobRequest where buffer excatly fits',
+    it('should get Parameters where the buffer is too large for one packet',
+      function (done) {
+        var writer = new Writer([TypeCode.BLOB]);
+        var inputBuffer = Buffer.from('larger than 5', 'ascii');
+        var stream = lib.util.stream.Readable.from([inputBuffer]);
+        var size = 15; // header is 10, buffer only has space for 5
+        
+        writer.setValues([stream]);
+        writer.getParameters(size, function (err, buffer) {
+          buffer.should.have.length(size);
+          buffer.slice(10).toString('ascii').should.equal(
+            'large');
+          stream.listenerCount('readable').should.equal(0);
+          // This source stream is wrapped because it is in object mode, so there 
+          // should be a error listener to forward errors to the wrapping stream
+          stream.listenerCount('error').should.equal(1);
+          stream.listenerCount('end').should.equal(0);
+
+          // simulate write lob reply
+          writer.update([Buffer.from([1, 2, 3, 4, 5, 6, 7, 8])]);
+
+          var remainingSize = 21 + inputBuffer.length - 5;
+          writer.getWriteLobRequest(remainingSize, function (err, part) {
+            part.argumentCount.should.equal(1);
+            part.buffer.should.have.length(remainingSize);
+            part.buffer.slice(21).toString('ascii').should.equal(
+              'r than 5');
+            stream.listenerCount('readable').should.equal(0);
+            stream.listenerCount('error').should.equal(0);
+            stream.listenerCount('end').should.equal(0);
+            done();
+          });
+        });
+      });
+
+    it('should get WriteLobRequest where buffer exactly fits',
       function (
         done) {
         var writer = new Writer([TypeCode.BLOB]);


### PR DESCRIPTION
- Modified finalizeParameters and finalizeWriteLobRequest in Writer to immediately read all available chunks on a readable event to avoid hanging on the stream
- Added support for Readable streams in object mode for LOB input
    - For streams inputted in object mode, they are wrapped in a LobTransform that is not in object mode to allow a specific number of bytes to be read at a time so that the buffer fits into the packetSize

Resolves SAP/node-hdb#215