### PR TITLE
fix: precision for long dates

### DIFF
--- a/lib/protocol/Writer.js
+++ b/lib/protocol/Writer.js
@@ -861,7 +861,7 @@ Writer.prototype[TypeCode.LONGDATE] = function writeLongDate(value) {
     hours = ~~ts[4];
     minutes = ~~ts[5];
     seconds = ~~ts[6];
-    nanoseconds = ~~((ts[6] * 1000000000) % 1000000000);
+    nanoseconds = ~~((ts[6] * 10000000) % 10000000);
   } else {
     throw createInputError('LONGDATE');
   }
@@ -877,7 +877,7 @@ Writer.prototype[TypeCode.LONGDATE] = function writeLongDate(value) {
   }
   const dayDate = calendar.DAYDATE(year, month, day);
   const dayFactor = BigInt(10000000) * BigInt(60 * 60 * 24);
-  const timeValue = BigInt(((hours * 60) + minutes) * 60 + seconds) * BigInt(10000000) + BigInt(~~(nanoseconds / 100));
+  const timeValue = BigInt(((hours * 60) + minutes) * 60 + seconds) * BigInt(10000000) + BigInt(nanoseconds);
   const longDate = BigInt(dayDate - 1) * dayFactor + timeValue + BigInt(1);
   var buffer = new Buffer(9);
   buffer[0] = TypeCode.LONGDATE;


### PR DESCRIPTION
We are experimenting with the new data format versions (see #278) that the new version has included and stumbled over a bug that caused a precision loss. This PR includes the minimum fix for our tests to succeed.

The following value provided for a LONGDATE `2025-07-21T09:15:33.873Z` results in a precision loss.

I also there's more improvement potential but that's for you to decide.

@IanMcCurdy FYI