### PR TITLE
fix: keep space for potential client info update segments.

### DIFF
--- a/lib/protocol/ClientInfo.js
+++ b/lib/protocol/ClientInfo.js
@@ -75,3 +75,11 @@ ClientInfo.prototype.getUpdatedProperties = function getUpdatedProperties() {
   return res;
 };
 
+ClientInfo.prototype.getUpdatedPropertiesSize = function getUpdatedProperties() {
+  var self = this;
+  var res = Object.keys(this._updatedProperties).reduce(function (p, c) {
+    p += c.length + self._properties[c].length
+    return p;
+  }, 0);
+  return res;
+};

--- a/lib/protocol/Connection.js
+++ b/lib/protocol/Connection.js
@@ -405,6 +405,7 @@ Connection.prototype.getAvailableSize = function getAvailableSize(forLobs = fals
   if (this._statementContext) {
     availableSize -= this._statementContext.size;
   }
+  availableSize -= this._clientInfo.getUpdatedPropertiesSize() + SEGMENT_HEADER_LENGTH
   return availableSize;
 };
 

--- a/test/lib.Connection.js
+++ b/test/lib.Connection.js
@@ -365,6 +365,16 @@ describe('Lib', function () {
       var c8 = createConnection({ packetSize: ps, packetSizeLimit: psl });
       c8.getAvailableSize(false).should.equal(packetSizeMax - totalHeaderLength);
       c8.getAvailableSize(true).should.equal(packetSizeMax - totalHeaderLength);
+
+      // client info property set
+      var c9 = createConnection();
+      c9._statementContext = {
+        size: 32,
+      };
+      c9.getClientInfo().setProperty('LOCALE', 'en_US');
+      var clientInfoSize = 11
+      c9.getAvailableSize().should.equal(packetSizeDefault - totalHeaderLength - 32 - clientInfoSize - 24);
+      c9.getAvailableSize(true).should.equal(packetSizeDefault - totalHeaderLength - 32 - clientInfoSize - 24);
     });
 
     it('should parse a reply', function () {


### PR DESCRIPTION
As part of `@cap-js/hana` for `@sap/cds` while implementing `prepare` statement re-use. Seemingly random `stmt.exec` calls started failing with the error [`Packet size limit exceeded`](https://github.com/SAP/node-hdb/blob/a54e41d20bbea3a09ed19ec226b79b9a5bab90ee/lib/protocol/Connection.js#L343).

After further investigations the following reproduction script showed the root cause:

```javascript
const prepare = await tx.dbc._prepare(`WITH A AS (SELECT ? AS JSON FROM DUMMY UNION ALL SELECT TO_BLOB(NULL) AS JSON FROM DUMMY) SELECT * FROM DUMMY`)

const gen = async function* () {
  for (let i = 0; i < 64; i++) yield Buffer.allocUnsafe(1024)
}
tx.dbc.set({'size': '64'}) // connection.getClientInfo().setProperty('size','64')
const res = await new Promise((resolve, reject) => {
  prepare.exec([Readable.from(gen(), { objectMode: false })], (err, res) => { if (err) { reject(err) } else { resolve(res) } })
})
```

When only using `hdb` it should look something like:

```javascript
const gen = async function* () {
  for (let i = 0; i < 64; i++) yield Buffer.allocUnsafe(1024)
}

connection.prepare(`WITH A AS (SELECT ? AS JSON FROM DUMMY UNION ALL SELECT TO_BLOB(NULL) AS JSON FROM DUMMY) SELECT * FROM DUMMY`, (err, stmt) => {
  connection.getClientInfo().setProperty('size', '64') // <== additional information not counted for total packet size
  stmt.exec([Readable.from(gen(), { objectMode: false })],(err, res) => {
    if(err) process.exit(1)
    process.exit(0)
  })
})
```

Currently uploading `LOB` parameters works with `hdb` only when another operation has happened between `getClientInfo().setProperty(...)` and `stmt.exec`. Which usually is fulfilled by calling `prepare` before `stmt.exec`.