### PR TITLE
[INFRA] fix npm publish workflow for OIDC trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,6 +3,7 @@ name: Publish to npm
 on:
   release:
     types: [published]
+  workflow_dispatch:
 
 jobs:
   publish:
@@ -18,7 +19,8 @@ jobs:
         with:
           package-manager-cache: false
           node-version: '22'
-      - run: echo "//registry.npmjs.org/:_authToken=" >> ~/.npmrc
+          registry-url: 'https://registry.npmjs.org'
+      - run: npm install -g npm@latest
       - run: npm ci
       - run: npm publish --provenance --access public
 


### PR DESCRIPTION
- restore registry-url so setup-node writes the auth-enabled .npmrc
- upgrade npm to latest before publishing — Node 22 ships with npm 10, but OIDC trusted publishing requires npm 11.5.1+
- drop the empty _authToken workaround that masked the underlying npm-version issue
- add workflow_dispatch so the workflow can be re-run manually without recreating a release