### PR TITLE
[INFRA] harden npm publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,7 +3,6 @@ name: Publish to npm
 on:
   release:
     types: [published]
-  workflow_dispatch:
 
 jobs:
   publish:
@@ -20,7 +19,7 @@ jobs:
           package-manager-cache: false
           node-version: '22'
           registry-url: 'https://registry.npmjs.org'
-      - run: npm install -g npm@latest
+      - run: npm install -g npm@11.17.0
       - run: npm ci
       - run: npm publish --provenance --access public
 


### PR DESCRIPTION
- pin npm to 11.17.0 (matches the version that worked) instead of floating @latest, so a future npm release can't silently break or compromise publishes
- remove workflow_dispatch now that the release-triggered flow is verified working — narrows trigger surface to the audit-trailed release path